### PR TITLE
java.lang.ClassNotFoundException

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ dependencies {
 //	implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
 	implementation 'org.modelmapper:modelmapper:3.1.0'
 	implementation 'nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect:3.1.0'
-
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 //	implementation 'io.springfox:springfox-boot-starter:3.0.0'
 //	implementation 'io.springfox:springfox-swagger-ui:3.0.0'
 


### PR DESCRIPTION
implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'

build gradle 의존성 추가